### PR TITLE
Disable WMS advanced projection handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Disable advanced projection handling
 - Update tomcat to 9.0.39 and GeoServer to 2.18.0
 
 ## [1.4.0-GS2.17.0]

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,8 @@ rm styles/*
 disable_services csw.xml wcs.xml wfs.xml
 popd
 
+cp wms.xml dist/data_dir/
+
 pushd dist
 docker run -it --rm \
     -v $(pwd)/../data/prg.7z:/data/prg.7z \

--- a/wms.xml
+++ b/wms.xml
@@ -1,0 +1,40 @@
+<wms>
+    <id>wms</id>
+    <enabled>true</enabled>
+    <name>Sat4Envi WMS</name>
+    <title>Sat4Envi WMS</title>
+    <maintainer></maintainer>
+    <accessConstraints>NONE</accessConstraints>
+    <fees>NONE</fees>
+    <versions>
+        <org.geotools.util.Version>
+            <version>1.1.1</version>
+        </org.geotools.util.Version>
+        <org.geotools.util.Version>
+            <version>1.3.0</version>
+        </org.geotools.util.Version>
+    </versions>
+    <keywords>
+        <string>WMS</string>
+        <string>Sat4Envi</string>
+    </keywords>
+    <citeCompliant>false</citeCompliant>
+    <onlineResource></onlineResource>
+    <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
+    <verbose>false</verbose>
+    <metadata>
+        <entry key="svgAntiAlias">true</entry>
+        <entry key="svgRenderer">Batik</entry>
+        <entry key="advancedProjectionHandling">false</entry>
+    </metadata>
+    <watermark class="org.geoserver.wms.WatermarkInfoImpl">
+        <enabled>false</enabled>
+        <position>BOT_RIGHT</position>
+        <transparency>0</transparency>
+    </watermark>
+    <interpolation>Nearest</interpolation>
+    <maxBuffer>25</maxBuffer>
+    <maxRequestMemory>0</maxRequestMemory>
+    <maxRenderingTime>0</maxRenderingTime>
+    <maxRenderingErrors>0</maxRenderingErrors>
+</wms>


### PR DESCRIPTION
Disabling it seems to solve the rectangular gaps issue for mosaic layers: cyfronet-fid/sat4envi#564.